### PR TITLE
add custom element for configured feature data

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -15,7 +15,7 @@ export namespace Components {
         "value"?: string;
     }
     interface ManifoldSubscriptionCreate {
-        "configuredFeatures"?: {
+        "configuredFeatures": {
             label: string;
             value: string;
         }[];
@@ -65,6 +65,7 @@ declare global {
 declare namespace LocalJSX {
     interface ManifoldConfiguredFeature {
         "label"?: string;
+        "onManifold-configured-feature-change"?: (event: CustomEvent<any>) => void;
         "value"?: string;
     }
     interface ManifoldSubscriptionCreate {

--- a/src/components/manifold-configured-feature/manifold-configured-feature.tsx
+++ b/src/components/manifold-configured-feature/manifold-configured-feature.tsx
@@ -1,17 +1,35 @@
-import { Component, Prop, Watch } from '@stencil/core';
+import { Component, Event, Prop, Watch } from '@stencil/core';
+import { EventEmitter } from '@manifoldco/manifold-init-types/types/stencil.core';
 
 @Component({
   tag: 'manifold-configured-feature',
 })
 export class ManifoldConfiguredFeature {
+  @Event({ eventName: 'manifold-configured-feature-change' })
+  propChange: EventEmitter;
+
   @Prop() label?: string;
-  @Watch('label') validateLabel(value?: string) {
+  @Watch('label') labelChange(value?: string) {
     this.isRequired('label', value);
   }
   @Prop() value?: string;
 
+  componentDidLoad() {
+    this.handlePropChange();
+  }
+  componentWillUpdate() {
+    this.handlePropChange();
+  }
+
+  handlePropChange() {
+    this.propChange.emit({
+      label: this.label,
+      value: this.value,
+    });
+  }
+
   isRequired(name: string, value?: any) {
-    if (value === undefined) {
+    if (!value) {
       throw new Error(`Prop ${name} on manifold-configured-feature is required`);
     }
   }

--- a/src/index.html
+++ b/src/index.html
@@ -31,11 +31,7 @@
     <script nomodule src="/build/manifold-subscription.js"></script>
   </head>
   <body>
-    <manifold-init
-      env="stage"
-      client-id="3zx3qeb15z70kcv4nh8cjedhndwz2"
-      auth-token="eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMWo2eDlnNjdoNjVkM3lkNjF6ajY4M2YyZDY4cCIsInN1YiI6Im1vdGhlck9EcmFnb25zIiwiaWF0IjoiMjAyMC0wMy0yNlQyMDoyMDoxNC40NDQxNjg2ODJaIiwiZXhwIjoiMjAyMC0wMy0yN1QyMDoyMDoxNC40NDQxNjg2ODJaIiwiYXVkIjoibWFuaWZvbGQuY28vZ2F0ZWtlZXBlciIsInZhbHVlIjoiZE1tUjVjcUgiLCJwbGF0Zm9ybSI6IjN6eDNxZWIxNXo3MGtjdjRuaDhjamVkaG5kd3oyIn0.hvKKZQnSkiOTxBuhBmQgQTeui4zqA-lnZLzsmfY8WrPN394jxqIoZgujy-z3hb46PeL6gX4p21_WlApRYHn5Jw"
-    ></manifold-init>
+    <manifold-init env="stage"></manifold-init>
     <manifold-subscription-create
       heading="Purchase Subscription"
       plan-id="235151h9fczz1wwv6zvxvrgw8x5ve"


### PR DESCRIPTION
## Change

Added a custom element for passing configured feature data to the subscription component.

### Usage

```html
<manifold-subscription-create plan-id="235151h9fczz1wwv6zvxvrgw8x5ve">
  <manifold-configured-feature label="my-string-feature" value="my-value"></manifold-configured-feature>
  <manifold-configured-feature label="my-number-feature" value="8"></manifold-configured-feature>
</manifold-subscription-create>
```

## Testing


