### PR TITLE
Details component fetches the subscription

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -46,7 +46,7 @@ export namespace Components {
         "subscribing"?: boolean;
     }
     interface ManifoldSubscriptionDetails {
-        "id": string;
+        "subscriptionId": string;
     }
     interface ManifoldSubscriptionList {
         "connection"?: Connection;
@@ -135,7 +135,7 @@ declare namespace LocalJSX {
         "subscribing"?: boolean;
     }
     interface ManifoldSubscriptionDetails {
-        "id"?: string;
+        "subscriptionId"?: string;
     }
     interface ManifoldSubscriptionList {
         "connection"?: Connection;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -45,6 +45,9 @@ export namespace Components {
         "stripePublishableKey": string;
         "subscribing"?: boolean;
     }
+    interface ManifoldSubscriptionDetails {
+        "id": string;
+    }
     interface ManifoldSubscriptionList {
         "connection"?: Connection;
         "data"?: SubscriptionsQuery;
@@ -73,6 +76,12 @@ declare global {
         prototype: HTMLManifoldSubscriptionCreateElement;
         new (): HTMLManifoldSubscriptionCreateElement;
     };
+    interface HTMLManifoldSubscriptionDetailsElement extends Components.ManifoldSubscriptionDetails, HTMLStencilElement {
+    }
+    var HTMLManifoldSubscriptionDetailsElement: {
+        prototype: HTMLManifoldSubscriptionDetailsElement;
+        new (): HTMLManifoldSubscriptionDetailsElement;
+    };
     interface HTMLManifoldSubscriptionListElement extends Components.ManifoldSubscriptionList, HTMLStencilElement {
     }
     var HTMLManifoldSubscriptionListElement: {
@@ -82,6 +91,7 @@ declare global {
     interface HTMLElementTagNameMap {
         "manifold-configured-feature": HTMLManifoldConfiguredFeatureElement;
         "manifold-subscription-create": HTMLManifoldSubscriptionCreateElement;
+        "manifold-subscription-details": HTMLManifoldSubscriptionDetailsElement;
         "manifold-subscription-list": HTMLManifoldSubscriptionListElement;
     }
 }
@@ -124,6 +134,9 @@ declare namespace LocalJSX {
         "stripePublishableKey"?: string;
         "subscribing"?: boolean;
     }
+    interface ManifoldSubscriptionDetails {
+        "id"?: string;
+    }
     interface ManifoldSubscriptionList {
         "connection"?: Connection;
         "data"?: SubscriptionsQuery;
@@ -141,6 +154,7 @@ declare namespace LocalJSX {
     interface IntrinsicElements {
         "manifold-configured-feature": ManifoldConfiguredFeature;
         "manifold-subscription-create": ManifoldSubscriptionCreate;
+        "manifold-subscription-details": ManifoldSubscriptionDetails;
         "manifold-subscription-list": ManifoldSubscriptionList;
     }
 }
@@ -150,6 +164,7 @@ declare module "@stencil/core" {
         interface IntrinsicElements {
             "manifold-configured-feature": LocalJSX.ManifoldConfiguredFeature & JSXBase.HTMLAttributes<HTMLManifoldConfiguredFeatureElement>;
             "manifold-subscription-create": LocalJSX.ManifoldSubscriptionCreate & JSXBase.HTMLAttributes<HTMLManifoldSubscriptionCreateElement>;
+            "manifold-subscription-details": LocalJSX.ManifoldSubscriptionDetails & JSXBase.HTMLAttributes<HTMLManifoldSubscriptionDetailsElement>;
             "manifold-subscription-list": LocalJSX.ManifoldSubscriptionList & JSXBase.HTMLAttributes<HTMLManifoldSubscriptionListElement>;
         }
     }

--- a/src/components/manifold-subscription-details/manifold-subscription-details.tsx
+++ b/src/components/manifold-subscription-details/manifold-subscription-details.tsx
@@ -1,0 +1,53 @@
+import { Component, Element, Prop, State, Watch, h } from '@stencil/core';
+import { Connection } from '@manifoldco/manifold-init-types/types/v0';
+import { SubscriptionQuery } from '../../types/graphql';
+import query from './subscription.graphql';
+
+@Component({
+  tag: 'manifold-subscription-details',
+})
+export class ManifoldSubscriptionCreate {
+  @Prop() id: string;
+  @State() data?: SubscriptionQuery;
+  @Element() el: HTMLElement;
+
+  connection: Connection;
+
+  @Watch('id')
+  async getSubscription(newValue: string, oldValue: string) {
+    if (!newValue) {
+      throw new Error(`Missing proprty \`id\` on ${this.el.tagName.toLocaleLowerCase()}`);
+    }
+
+    if (newValue !== oldValue) {
+      const response = await this.connection.graphqlFetch<SubscriptionQuery>({
+        query,
+        variables: { id: newValue },
+      });
+
+      if (response.data) {
+        this.data = response.data;
+      }
+    }
+  }
+
+  async componentWillLoad() {
+    await customElements.whenDefined('manifold-init');
+    const core = document.querySelector('manifold-init') as HTMLManifoldInitElement;
+    this.connection = await core.initialize({
+      element: this.el,
+      componentVersion: '<@NPM_PACKAGE_VERSION@>',
+      version: 0,
+    });
+
+    this.getSubscription(this.id, '');
+  }
+
+  render() {
+    if (this.data?.subscription) {
+      return <h3>{this.data.subscription.plan.displayName}</h3>;
+    }
+
+    return null;
+  }
+}

--- a/src/components/manifold-subscription-details/manifold-subscription-details.tsx
+++ b/src/components/manifold-subscription-details/manifold-subscription-details.tsx
@@ -7,13 +7,13 @@ import query from './subscription.graphql';
   tag: 'manifold-subscription-details',
 })
 export class ManifoldSubscriptionCreate {
-  @Prop() id: string;
+  @Prop() subscriptionId: string;
   @State() data?: SubscriptionQuery;
   @Element() el: HTMLElement;
 
   connection: Connection;
 
-  @Watch('id')
+  @Watch('subscriptionId')
   async getSubscription(newValue: string, oldValue: string) {
     if (!newValue) {
       throw new Error(`Missing proprty \`id\` on ${this.el.tagName.toLocaleLowerCase()}`);
@@ -40,7 +40,7 @@ export class ManifoldSubscriptionCreate {
       version: 0,
     });
 
-    this.getSubscription(this.id, '');
+    this.getSubscription(this.subscriptionId, '');
   }
 
   render() {

--- a/src/components/manifold-subscription-details/subscription.graphql
+++ b/src/components/manifold-subscription-details/subscription.graphql
@@ -1,0 +1,38 @@
+query Subscription($id: ID!) {
+  subscription(id: $id) {
+    status {
+      label
+      percentDone
+      message
+    }
+    plan {
+      label
+      displayName
+      fixedFeatures(first: 100) {
+        edges {
+          node {
+            label
+            displayName
+            displayValue
+          }
+        }
+      }
+      meteredFeatures(first: 100) {
+        edges {
+          node {
+            label
+            displayName
+          }
+        }
+      }
+      configurableFeatures(first: 100) {
+        edges {
+          node {
+            label
+            displayName
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -31,13 +31,6 @@
     <script nomodule src="/build/manifold-subscription.js"></script>
   </head>
   <body>
-    <!--
-    <manifold-init
-      auth-token="eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMWoyM3ZrdDZwY3A1eDg0NjRlZXZ4ZTI4NGg4ZyIsInN1YiI6ImJyYW4iLCJpYXQiOiIyMDIwLTA0LTE1VDE2OjI1OjIxLjM2Nzg5MDgxWiIsImV4cCI6IjIwMjAtMDQtMTZUMTY6MjU6MjEuMzY3ODkwODFaIiwiYXVkIjoibWFuaWZvbGQuY28vZ2F0ZWtlZXBlciIsInZhbHVlIjoiTDVYajgtOFMiLCJwbGF0Zm9ybSI6IjN6eDNxZWIxNXo3MGtjdjRuaDhjamVkaG5kd3oyIiwidG9rZW5fc2VjcmV0IjoiaDVxcDd1eTdMTnA0MTR2bjJTMUxnYzFuVm1XOEJuRGxvQXpiY0Nvb05wYVNuQ2oxT3BRZW1jUUphQmNCIn0.77WgsDjSnOFYTTASofYewNzsdNPNO9hjbqZuWXGFIs0zVj3XxVceUUAzD5WQcyl-fjD47mp9E8YN5E3N15XA0g"
-      env="stage"
-      client-id="3zx3qeb15z70kcv4nh8cjedhndwz2"
-    ></manifold-init>
-    -->
     <manifold-init env="stage" client-id="3zx3qeb15z70kcv4nh8cjedhndwz2"></manifold-init>
     <h2>Create a subscription</h2>
     <manifold-subscription-create

--- a/src/index.html
+++ b/src/index.html
@@ -49,7 +49,7 @@
     ></manifold-subscription-list>
     <h2>View subscription details</h2>
     <manifold-subscription-details
-      id="2475k59d5tbk57p95v5w8x4rb4mnp"
+      subscription-id="2475k59d5tbk57p95v5w8x4rb4mnp"
     ></manifold-subscription-details>
 
     <script>

--- a/src/index.html
+++ b/src/index.html
@@ -31,7 +31,15 @@
     <script nomodule src="/build/manifold-subscription.js"></script>
   </head>
   <body>
+    <!--
+    <manifold-init
+      auth-token="eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMWoyM3ZrdDZwY3A1eDg0NjRlZXZ4ZTI4NGg4ZyIsInN1YiI6ImJyYW4iLCJpYXQiOiIyMDIwLTA0LTE1VDE2OjI1OjIxLjM2Nzg5MDgxWiIsImV4cCI6IjIwMjAtMDQtMTZUMTY6MjU6MjEuMzY3ODkwODFaIiwiYXVkIjoibWFuaWZvbGQuY28vZ2F0ZWtlZXBlciIsInZhbHVlIjoiTDVYajgtOFMiLCJwbGF0Zm9ybSI6IjN6eDNxZWIxNXo3MGtjdjRuaDhjamVkaG5kd3oyIiwidG9rZW5fc2VjcmV0IjoiaDVxcDd1eTdMTnA0MTR2bjJTMUxnYzFuVm1XOEJuRGxvQXpiY0Nvb05wYVNuQ2oxT3BRZW1jUUphQmNCIn0.77WgsDjSnOFYTTASofYewNzsdNPNO9hjbqZuWXGFIs0zVj3XxVceUUAzD5WQcyl-fjD47mp9E8YN5E3N15XA0g"
+      env="stage"
+      client-id="3zx3qeb15z70kcv4nh8cjedhndwz2"
+    ></manifold-init>
+    -->
     <manifold-init env="stage" client-id="3zx3qeb15z70kcv4nh8cjedhndwz2"></manifold-init>
+    <h2>Create a subscription</h2>
     <manifold-subscription-create
       heading="Purchase Subscription"
       plan-id="235151h9fczz1wwv6zvxvrgw8x5ve"
@@ -40,10 +48,17 @@
       <manifold-configured-feature label="crackers" value="true"></manifold-configured-feature>
       <manifold-configured-feature label="juice" value="60"></manifold-configured-feature>
     </manifold-subscription-create>
+
+    <h2>List subscriptions</h2>
     <manifold-subscription-list
       heading="Your Subscriptions"
       owner="fake-owner-id"
     ></manifold-subscription-list>
+    <h2>View subscription details</h2>
+    <manifold-subscription-details
+      id="2475k59d5tbk57p95v5w8x4rb4mnp"
+    ></manifold-subscription-details>
+
     <script>
       const createElement = document.querySelector('manifold-subscription-create');
       createElement.addEventListener('success', e => {

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1447,6 +1447,53 @@ export type PlanQuery = (
   ) }
 );
 
+export type SubscriptionQueryVariables = {
+  id: Scalars['ID'];
+};
+
+
+export type SubscriptionQuery = (
+  { __typename?: 'Query' }
+  & { subscription: Maybe<(
+    { __typename?: 'SubscriptionAgreement' }
+    & { status: (
+      { __typename?: 'SubscriptionAgreementStatus' }
+      & Pick<SubscriptionAgreementStatus, 'label' | 'percentDone' | 'message'>
+    ), plan: Maybe<(
+      { __typename?: 'Plan' }
+      & Pick<Plan, 'label' | 'displayName'>
+      & { fixedFeatures: Maybe<(
+        { __typename?: 'PlanFixedFeatureConnection' }
+        & { edges: Array<(
+          { __typename?: 'PlanFixedFeatureEdge' }
+          & { node: (
+            { __typename?: 'PlanFixedFeature' }
+            & Pick<PlanFixedFeature, 'label' | 'displayName' | 'displayValue'>
+          ) }
+        )> }
+      )>, meteredFeatures: Maybe<(
+        { __typename?: 'PlanMeteredFeatureConnection' }
+        & { edges: Array<(
+          { __typename?: 'PlanMeteredFeatureEdge' }
+          & { node: (
+            { __typename?: 'PlanMeteredFeature' }
+            & Pick<PlanMeteredFeature, 'label' | 'displayName'>
+          ) }
+        )> }
+      )>, configurableFeatures: Maybe<(
+        { __typename?: 'PlanConfigurableFeatureConnection' }
+        & { edges: Array<(
+          { __typename?: 'PlanConfigurableFeatureEdge' }
+          & { node: (
+            { __typename?: 'PlanConfigurableFeature' }
+            & Pick<PlanConfigurableFeature, 'label' | 'displayName'>
+          ) }
+        )> }
+      )> }
+    )> }
+  )> }
+);
+
 export type SubscriptionsQueryVariables = {
   owner: Scalars['ProfileIdentity'];
 };


### PR DESCRIPTION
## Change

Adds a component to display the subscription details. Currently just fetches the subscription from GraphQL and shows the plan's `displayName`.


## Testing

To test locally with the dev server, try the following:

1. Get an auth token for Bran 
1. Insert that token as an `auth-token` attribute for `manifold-init`
1. Start your dev server

You should see this:

![image](https://user-images.githubusercontent.com/374078/79370583-8c6b3400-7f18-11ea-9e0f-06ebd5642c3a.png)

