### PR TITLE
subscription details

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -46,6 +46,7 @@ export namespace Components {
         "subscribing"?: boolean;
     }
     interface ManifoldSubscriptionDetails {
+        "heading"?: string;
         "subscriptionId": string;
     }
     interface ManifoldSubscriptionList {
@@ -135,6 +136,7 @@ declare namespace LocalJSX {
         "subscribing"?: boolean;
     }
     interface ManifoldSubscriptionDetails {
+        "heading"?: string;
         "subscriptionId"?: string;
     }
     interface ManifoldSubscriptionList {

--- a/src/components/manifold-subscription-create/manifold-subscription-create.tsx
+++ b/src/components/manifold-subscription-create/manifold-subscription-create.tsx
@@ -328,6 +328,7 @@ export class ManifoldSubscriptionCreate {
           <button
             class="ManifoldSubscriptionCreate__Button"
             type="submit"
+            data-kind="primary"
             disabled={this.subscribing}
           >
             {this.subscribing ? 'Subscribing...' : 'Subscribe with Card'}

--- a/src/components/manifold-subscription-details/manifold-subscription-details.tsx
+++ b/src/components/manifold-subscription-details/manifold-subscription-details.tsx
@@ -54,7 +54,7 @@ export class ManifoldSubscriptionCreate {
   }
 
   render() {
-    if (!this.data) {
+    if (!this.data || !this.data.subscription) {
       return null;
     }
 

--- a/src/components/manifold-subscription-details/manifold-subscription-details.tsx
+++ b/src/components/manifold-subscription-details/manifold-subscription-details.tsx
@@ -1,13 +1,23 @@
 import { Component, Element, Prop, State, Watch, h } from '@stencil/core';
 import { Connection } from '@manifoldco/manifold-init-types/types/v0';
-import { SubscriptionQuery } from '../../types/graphql';
+import FixedFeature from 'components/shared/FixedFeature';
+import MeteredFeature from 'components/shared/MeteredFeature';
+import ConfigurableFeature from 'components/shared/ConfigurableFeature';
+import CostDisplay from 'components/shared/CostDisplay';
 import query from './subscription.graphql';
+import {
+  SubscriptionQuery,
+  PlanFixedFeatureEdge,
+  PlanMeteredFeatureEdge,
+  PlanConfigurableFeatureEdge,
+} from '../../types/graphql';
 
 @Component({
   tag: 'manifold-subscription-details',
 })
 export class ManifoldSubscriptionCreate {
   @Prop() subscriptionId: string;
+  @Prop() heading?: string;
   @State() data?: SubscriptionQuery;
   @Element() el: HTMLElement;
 
@@ -44,10 +54,50 @@ export class ManifoldSubscriptionCreate {
   }
 
   render() {
-    if (this.data?.subscription) {
-      return <h3>{this.data.subscription.plan.displayName}</h3>;
+    if (!this.data) {
+      return null;
     }
 
-    return null;
+    const { plan, status } = this.data.subscription;
+
+    return (
+      <div class="ManifoldSubscriptionCreate__Details">
+        {this.heading && <h1 class="ManifoldSubscriptionCreate__Heading">{this.heading}</h1>}
+        <section class="ManifoldSubscriptionCreate__Card">
+          <header class="ManifoldSubscriptionCreate__Details__Header">
+            <h2 class="ManifoldSubscriptionCreate__PlanName">{plan.displayName}</h2>
+            <h3 class="ManifoldSubscriptionCreate__SubscriptionStatus" data-status={status.label}>
+              <div class="ManifoldSubscriptionCreate__SubscriptionStatusIndicator" />
+              {status.label}
+            </h3>
+          </header>
+          <dl class="ManifoldSubscriptionCreate__Details__FeatureList">
+            {plan.fixedFeatures.edges.map(fixedFeature => (
+              <FixedFeature fixedFeature={fixedFeature as PlanFixedFeatureEdge} />
+            ))}
+            {plan.meteredFeatures.edges.map(meteredFeature => (
+              <MeteredFeature meteredFeature={meteredFeature as PlanMeteredFeatureEdge} />
+            ))}
+            {plan.configurableFeatures.edges.map(configurableFeature => (
+              // TODO format configured feature so it displays as fixed
+              <ConfigurableFeature
+                setConfiguredFeature={() => null}
+                configurableFeature={configurableFeature as PlanConfigurableFeatureEdge}
+              />
+            ))}
+          </dl>
+          <footer class="ManifoldSubscriptionCreate__PlanSelector__Footer">
+            <div>
+              {/* TODO use actual subscription cost */}
+              <CostDisplay baseCost={plan.cost} />
+              <p class="ManifoldSubscriptionCreate__HelpText">Usage billed at the end of month</p>
+            </div>
+            <button type="button" class="ManifoldSubscriptionCreate__Button" data-kind="black">
+              Modify Subsciption
+            </button>
+          </footer>
+        </section>
+      </div>
+    );
   }
 }

--- a/src/components/manifold-subscription-details/subscription.graphql
+++ b/src/components/manifold-subscription-details/subscription.graphql
@@ -6,30 +6,57 @@ query Subscription($id: ID!) {
       message
     }
     plan {
+      id
       label
       displayName
-      fixedFeatures(first: 100) {
+      cost
+      fixedFeatures(first: 500) {
         edges {
           node {
-            label
             displayName
             displayValue
+            label
           }
         }
       }
-      meteredFeatures(first: 100) {
+      meteredFeatures(first: 500) {
         edges {
           node {
             label
             displayName
+            numericDetails {
+              unit
+              costTiers {
+                limit
+                cost
+              }
+            }
           }
         }
       }
-      configurableFeatures(first: 100) {
+      configurableFeatures(first: 500) {
         edges {
           node {
             label
             displayName
+            type
+            upgradable
+            downgradable
+            featureOptions {
+              displayName
+              value
+              cost
+            }
+            numericDetails {
+              increment
+              min
+              max
+              unit
+              costTiers {
+                limit
+                cost
+              }
+            }
           }
         }
       }

--- a/src/components/shared/PlanCard.tsx
+++ b/src/components/shared/PlanCard.tsx
@@ -21,11 +21,13 @@ const PlanCard: FunctionalComponent<PlanCardProps> = (
   cta
 ) => (
   <div class="ManifoldSubscriptionCreate__Card" data-is-checked={isChecked}>
-    <div class="ManifoldSubscriptionCreate__PlanName" data-is-loading={isLoading}>
-      {plan.displayName}
+    <div class="ManifoldSubscriptionCreate__PlanName">
+      <span data-is-loading={isLoading}>{plan.displayName}</span>
     </div>
-    <span class="ManifoldSubscriptionCreate__Cost" data-is-loading={isLoading}>
-      <CostDisplay baseCost={plan.cost} isConfigurable compact />
+    <span class="ManifoldSubscriptionCreate__Cost">
+      <span data-is-loading={isLoading}>
+        <CostDisplay baseCost={plan.cost} isConfigurable compact />
+      </span>
     </span>
     {cta}
     <i class="ManifoldSubscriptionCreate__Card__Checkmark" innerHTML={check} />

--- a/src/components/shared/PlanSelector.tsx
+++ b/src/components/shared/PlanSelector.tsx
@@ -114,13 +114,17 @@ const PlanSelector: FunctionalComponent<PlanSelectorProps> = props => {
         </dl>
         {/* TODO add regions */}
         <footer class="ManifoldSubscriptionCreate__PlanSelector__Footer">
-          <CostDisplay
-            isCalculating={props.calculatedCost === undefined}
-            baseCost={props.calculatedCost || currentPlan?.cost || 0}
-            meteredFeatures={currentPlan?.meteredFeatures.edges as PlanMeteredFeatureEdge[]}
-            isConfigurable={currentPlan ? currentPlan.configurableFeatures.edges.length > 0 : false}
-          />
-          <p class="ManifoldSubscriptionCreate__HelpText">Usage billed at the end of month</p>
+          <div>
+            <CostDisplay
+              isCalculating={props.calculatedCost === undefined}
+              baseCost={props.calculatedCost || currentPlan?.cost || 0}
+              meteredFeatures={currentPlan?.meteredFeatures.edges as PlanMeteredFeatureEdge[]}
+              isConfigurable={
+                currentPlan ? currentPlan.configurableFeatures.edges.length > 0 : false
+              }
+            />
+            <p class="ManifoldSubscriptionCreate__HelpText">Usage billed at the end of month</p>
+          </div>
         </footer>
       </div>
     </div>

--- a/src/styles/elements/_button.scss
+++ b/src/styles/elements/_button.scss
@@ -4,8 +4,16 @@ $name: '' !default;
 .#{$name}__Button {
   @include mercury.Manifold__Button;
 
-  color: mercury.$color-white;
-  text-align: center;
-  background-image: mercury.$gradient-blue;
-  border-color: transparent;
+  &[data-kind='primary'] {
+    color: mercury.$color-white;
+    text-align: center;
+    background-image: mercury.$gradient-blue;
+    border-color: transparent;
+  }
+
+  &[data-kind='black'] {
+    color: mercury.$color-white;
+    background-color: mercury.$color-black;
+    border-color: transparent;
+  }
 }

--- a/src/styles/elements/_card.scss
+++ b/src/styles/elements/_card.scss
@@ -5,7 +5,6 @@ $name: '' !default;
   position: relative;
   display: grid;
   gap: 0.5em;
-  justify-items: start;
   padding: 1em;
   background-color: mercury.$color-white;
   border: 1px solid mercury.$color-gray;

--- a/src/styles/elements/_plan-selector.scss
+++ b/src/styles/elements/_plan-selector.scss
@@ -134,7 +134,10 @@ $name: '' !default;
 
   &__Footer {
     display: grid;
-    gap: 0.25em;
+    grid-auto-columns: 1fr auto;
+    grid-auto-flow: column;
+    gap: 1em;
+    align-content: space-between;
     align-items: center;
     padding: 1em;
 

--- a/src/styles/elements/_subscription-create.scss
+++ b/src/styles/elements/_subscription-create.scss
@@ -8,11 +8,6 @@ $name: '' !default;
   color: mercury.$color-grayDarker;
   font-size: 1em;
 
-  &__Heading {
-    font-size: 1.5em;
-    text-align: center;
-  }
-
   &__Form {
     display: grid;
     grid-template-columns: 1fr;

--- a/src/styles/elements/_subscription-details.scss
+++ b/src/styles/elements/_subscription-details.scss
@@ -1,0 +1,57 @@
+@use "node_modules/@manifoldco/mercury";
+$name: '' !default;
+
+.#{$name}__Details {
+  display: grid;
+  gap: 1em;
+
+  .#{$name}__Card {
+    padding: 0;
+  }
+
+  &__Header {
+    display: grid;
+    grid-auto-flow: column;
+    gap: 0.75em;
+    align-items: center;
+    justify-content: start;
+    padding: 1em 1.5em;
+    border-bottom: 1px solid mercury.$color-grayLight;
+  }
+
+  .#{$name}__PlanName {
+    font-size: 1.25em;
+  }
+
+  &__FeatureList {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    // temporary
+    padding: 0.5em;
+  }
+
+  // TODO refactor to class
+  footer {
+    border-top: 1px solid mercury.$color-grayLight;
+  }
+}
+
+.#{$name}__SubscriptionStatus {
+  display: flex;
+  align-items: center;
+  padding: 0.5em 0.75em;
+  color: mercury.$color-grayDark;
+  font-size: 0.6em;
+  line-height: 1;
+  border: 1px solid mercury.$color-grayLight;
+  border-radius: 2em;
+
+  &Indicator {
+    display: inline-block;
+    width: 0.8em;
+    height: 0.8em;
+    margin-right: 0.75em;
+    background-color: mercury.$color-green;
+    border-radius: 1em;
+  }
+}

--- a/src/styles/elements/_typography.scss
+++ b/src/styles/elements/_typography.scss
@@ -1,0 +1,9 @@
+@use "node_modules/@manifoldco/mercury";
+$name: '' !default;
+
+.#{$name} {
+  &__Heading {
+    font-size: 1.5em;
+    text-align: center;
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -2,7 +2,9 @@
 $name: 'ManifoldSubscriptionCreate';
 
 @use 'elements/subscription-create' with ($name: $name);
+@use 'elements/subscription-details' with ($name: $name);
 @use 'elements/subscription-list' with ($name: $name);
+@use 'elements/typography' with ($name: $name);
 @use 'elements/card' with ($name: $name);
 @use 'elements/cost' with ($name: $name);
 @use 'elements/field' with ($name: $name);
@@ -14,7 +16,9 @@ $name: 'ManifoldSubscriptionCreate';
 @use 'elements/plan-selector' with ($name: $name);
 @use 'elements/skeleton' with ($name: $name);
 
-manifold-subscription-create, manifold-subscription-list {
+manifold-subscription-create,
+manifold-subscription-details,
+manifold-subscription-list {
   box-sizing: border-box;
 
   button,

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1163,12 +1163,14 @@ export type StringConfiguredFeature = ConfiguredFeature & {
 export type StripeAccount = {
    __typename?: 'StripeAccount';
   id: Scalars['String'];
+  business_name: Scalars['String'];
   business_type: StripeBusinessType;
   capabilities: StripeCapabilities;
-  representative: Maybe<StripePerson>;
+  support_email: Scalars['String'];
 };
 
 export enum StripeBusinessType {
+  Unknown = 'UNKNOWN',
   Individual = 'INDIVIDUAL',
   Company = 'COMPANY',
   NonProfit = 'NON_PROFIT',
@@ -1182,17 +1184,11 @@ export type StripeCapabilities = {
 };
 
 export enum StripeCapabilityStatus {
+  Unknown = 'UNKNOWN',
   Active = 'ACTIVE',
   Inactive = 'INACTIVE',
   Pending = 'PENDING'
 }
-
-export type StripePerson = {
-   __typename?: 'StripePerson';
-  email: Maybe<Scalars['String']>;
-  first_name: Maybe<Scalars['String']>;
-  last_name: Maybe<Scalars['String']>;
-};
 
 export type SubLineItem = {
    __typename?: 'SubLineItem';
@@ -1461,14 +1457,14 @@ export type SubscriptionQuery = (
       & Pick<SubscriptionAgreementStatus, 'label' | 'percentDone' | 'message'>
     ), plan: Maybe<(
       { __typename?: 'Plan' }
-      & Pick<Plan, 'label' | 'displayName'>
+      & Pick<Plan, 'label' | 'displayName' | 'cost'>
       & { fixedFeatures: Maybe<(
         { __typename?: 'PlanFixedFeatureConnection' }
         & { edges: Array<(
           { __typename?: 'PlanFixedFeatureEdge' }
           & { node: (
             { __typename?: 'PlanFixedFeature' }
-            & Pick<PlanFixedFeature, 'label' | 'displayName' | 'displayValue'>
+            & Pick<PlanFixedFeature, 'displayName' | 'displayValue' | 'label'>
           ) }
         )> }
       )>, meteredFeatures: Maybe<(
@@ -1478,6 +1474,14 @@ export type SubscriptionQuery = (
           & { node: (
             { __typename?: 'PlanMeteredFeature' }
             & Pick<PlanMeteredFeature, 'label' | 'displayName'>
+            & { numericDetails: (
+              { __typename?: 'PlanMeteredFeatureNumericDetails' }
+              & Pick<PlanMeteredFeatureNumericDetails, 'unit'>
+              & { costTiers: Maybe<Array<(
+                { __typename?: 'PlanFeatureCostTier' }
+                & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+              )>> }
+            ) }
           ) }
         )> }
       )>, configurableFeatures: Maybe<(
@@ -1486,7 +1490,18 @@ export type SubscriptionQuery = (
           { __typename?: 'PlanConfigurableFeatureEdge' }
           & { node: (
             { __typename?: 'PlanConfigurableFeature' }
-            & Pick<PlanConfigurableFeature, 'label' | 'displayName'>
+            & Pick<PlanConfigurableFeature, 'label' | 'displayName' | 'type' | 'upgradable' | 'downgradable'>
+            & { featureOptions: Maybe<Array<(
+              { __typename?: 'PlanConfigurableFeatureOption' }
+              & Pick<PlanConfigurableFeatureOption, 'displayName' | 'value' | 'cost'>
+            )>>, numericDetails: Maybe<(
+              { __typename?: 'PlanConfigurableFeatureNumericDetails' }
+              & Pick<PlanConfigurableFeatureNumericDetails, 'increment' | 'min' | 'max' | 'unit'>
+              & { costTiers: Maybe<Array<(
+                { __typename?: 'PlanFeatureCostTier' }
+                & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+              )>> }
+            )> }
           ) }
         )> }
       )> }


### PR DESCRIPTION
## Change

- built out default view for subscription details (it's still somewhat a wip, but it's a decent start i think)

Note: just filter to the last commit since it's branched off the "move shared components" PR so that adds a lot to the diff

<img width="1016" alt="Screen Shot 2020-04-16 at 6 08 18 AM" src="https://user-images.githubusercontent.com/10498708/79438440-e5cf7380-7fa9-11ea-868c-567a235c2833.png">



## Testing


