### PR TITLE
add UI to update auth token

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -53,7 +53,7 @@
       }
 
       .auth input,
-      button {
+      .auth button {
         padding: 0.5rem;
         color: inherit;
         font-family: 'Roboto Mono', Menlo, monospace;

--- a/src/index.html
+++ b/src/index.html
@@ -27,10 +27,47 @@
       src="https://js.cdn.manifold.co/@manifoldco/manifold-init/dist/manifold-init/manifold-init.js"
     ></script>
 
+    <script type="module" src="/build/index.esm.js"></script>
+    <script nomodule src="/build/index.js"></script>
+
     <script type="module" src="/build/manifold-subscription.esm.js"></script>
     <script nomodule src="/build/manifold-subscription.js"></script>
+    <style>
+      body {
+        margin-top: 4rem;
+        background-color: #f8f8f8;
+      }
+      .auth {
+        position: fixed;
+        top: 0;
+        right: 0;
+        left: 0;
+        display: grid;
+        grid-template-columns: auto 1fr auto;
+        gap: 0.5rem;
+        align-items: center;
+        padding: 0.5rem;
+        color: #888;
+        background-color: #111;
+        box-shadow: 0 0 10px #0002;
+      }
+
+      .auth input,
+      button {
+        padding: 0.5rem;
+        color: inherit;
+        font-family: 'Roboto Mono', Menlo, monospace;
+        background-color: #fff1;
+        border: 1px solid #fff2;
+      }
+    </style>
   </head>
   <body>
+    <label class="auth">
+      Auth Token:
+      <input id="auth-token" type="text" placeholder="Manifold Auth Token" />
+      <button id="update-auth-token" type="button">Update</button>
+    </label>
     <manifold-init env="stage" client-id="3zx3qeb15z70kcv4nh8cjedhndwz2"></manifold-init>
     <h2>Create a subscription</h2>
     <manifold-subscription-create

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,24 @@
-export * from './components';
+(async () => {
+  await customElements.whenDefined('manifold-init');
+
+  const manifoldInitElement: HTMLManifoldInitElement = document.getElementsByTagName(
+    'manifold-init'
+  )[0];
+
+  manifoldInitElement.authToken = '<@MANIFOLD_API_TOKEN@>';
+
+  const updateTokenButton = document.getElementById('update-auth-token') as HTMLButtonElement;
+  const tokenInput = document.getElementById('auth-token') as HTMLInputElement;
+
+  if (updateTokenButton && tokenInput) {
+    const token = localStorage.getItem('manifold_api_token') || '';
+    tokenInput.value = token;
+    manifoldInitElement.authToken = token;
+
+    updateTokenButton.addEventListener('click', () => {
+      const { value } = tokenInput;
+      localStorage.setItem('manifold_api_token', value);
+      manifoldInitElement.authToken = value;
+    });
+  }
+})();


### PR DESCRIPTION
## Change

Maybe we should add storybook soon, but this is a good short-term DX improvement.

- added input to update auth token in dev UI
- added off-white background to the body (makes it easier to see when things don't have a background but they should)

<img width="762" alt="Screen Shot 2020-04-20 at 10 44 32 AM" src="https://user-images.githubusercontent.com/10498708/79758863-5224dc80-82f4-11ea-9930-0cd87a04b9ff.png">



## Testing

- add auth token from taco cloud stage, do the components work?
- refresh the page. is the token still there and working?

great! it works!

