### PR TITLE
calc cost on plan card

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -17,7 +17,7 @@ export namespace Components {
         "value"?: string | number | boolean;
     }
     interface ManifoldSubscriptionCreate {
-        "calculatedCost"?: number;
+        "calculatedCost"?: number | null;
         "configuredFeatures": FeatureMap;
         "data"?: PlanQuery;
         /**
@@ -111,7 +111,7 @@ declare namespace LocalJSX {
         "value"?: string | number | boolean;
     }
     interface ManifoldSubscriptionCreate {
-        "calculatedCost"?: number;
+        "calculatedCost"?: number | null;
         "configuredFeatures"?: FeatureMap;
         "data"?: PlanQuery;
         /**

--- a/src/components/manifold-subscription-create/manifold-subscription-create.tsx
+++ b/src/components/manifold-subscription-create/manifold-subscription-create.tsx
@@ -56,7 +56,7 @@ export class ManifoldSubscriptionCreate {
   @Prop({ mutable: true }) setupIntentError?: string;
   @Prop({ mutable: true }) subscribing?: boolean = false;
   @Prop({ mutable: true }) configuredFeatures: FeatureMap = {};
-  @Prop({ mutable: true }) calculatedCost?: number;
+  @Prop({ mutable: true }) calculatedCost?: number | null;
   @Prop({ mutable: true }) isEditing: boolean = false;
 
   /**
@@ -219,7 +219,7 @@ export class ManifoldSubscriptionCreate {
 
     // if not configurable, return plan cost
     if (Object.keys(this.configuredFeatures).length === 0) {
-      this.calculatedCost = 0;
+      this.calculatedCost = undefined;
       return undefined;
     }
 
@@ -229,7 +229,7 @@ export class ManifoldSubscriptionCreate {
     }
 
     // Hide display while calculating
-    this.calculatedCost = undefined;
+    this.calculatedCost = null;
 
     // If a request is in flight, cancel it
     if (this.controller) {

--- a/src/components/manifold-subscription-create/manifold-subscription-create.tsx
+++ b/src/components/manifold-subscription-create/manifold-subscription-create.tsx
@@ -427,6 +427,7 @@ export class ManifoldSubscriptionCreate {
             <PlanCard
               isLoading={this.loading}
               plan={this.data?.plan || undefined}
+              calculatedCost={this.calculatedCost}
               errors={filterErrors(this.errors, 'label', ['plan-query'])}
             >
               <button

--- a/src/components/manifold-subscription-create/plan.graphql
+++ b/src/components/manifold-subscription-create/plan.graphql
@@ -5,6 +5,13 @@ query Plan($planId: ID!) {
     product {
       label
     }
+    configurableFeatures(first: 1) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
   }
   profile {
     stripeSetupIntentSecret

--- a/src/components/shared/PlanCard.tsx
+++ b/src/components/shared/PlanCard.tsx
@@ -1,5 +1,6 @@
 import { h, FunctionalComponent } from '@stencil/core';
 import check from '@manifoldco/mercury/icons/check.svg';
+import sliders from '@manifoldco/mercury/icons/sliders.svg';
 import CostDisplay from './CostDisplay';
 import { UIError } from '../../utils/error';
 
@@ -10,6 +11,9 @@ interface PlanCardProps {
   plan?: {
     displayName: string;
     cost: number;
+    configurableFeatures?: {
+      edges: object[];
+    };
   };
 }
 
@@ -26,10 +30,19 @@ const PlanCard: FunctionalComponent<PlanCardProps> = (
     return null;
   }
 
+  const isConfigurable = (plan.configurableFeatures?.edges.length || 0) > 0;
+
   return (
     <div class="ManifoldSubscriptionCreate__Card" data-is-checked={isChecked}>
       <div class="ManifoldSubscriptionCreate__PlanName">
         <span data-is-loading={isLoading}>{plan.displayName}</span>
+        {isConfigurable && (
+          <i
+            class="ManifoldSubscriptionCreate__Card__ConfigurableIndicator"
+            innerHTML={sliders}
+            title="Configurable"
+          />
+        )}
       </div>
       <span class="ManifoldSubscriptionCreate__Cost">
         <span data-is-loading={isLoading}>

--- a/src/components/shared/PlanCard.tsx
+++ b/src/components/shared/PlanCard.tsx
@@ -7,6 +7,7 @@ import { UIError } from '../../utils/error';
 interface PlanCardProps {
   isLoading?: boolean;
   isChecked?: boolean;
+  calculatedCost?: number;
   errors?: UIError[];
   plan?: {
     displayName: string;
@@ -22,10 +23,9 @@ const defaultPlan: PlanCardProps['plan'] = {
   cost: 100,
 };
 
-const PlanCard: FunctionalComponent<PlanCardProps> = (
-  { isLoading, isChecked, plan = defaultPlan, errors = [] },
-  cta
-) => {
+const PlanCard: FunctionalComponent<PlanCardProps> = (props, cta) => {
+  const { isLoading, isChecked, plan = defaultPlan, calculatedCost, errors = [] } = props;
+
   if (errors.length > 0) {
     return null;
   }
@@ -46,7 +46,12 @@ const PlanCard: FunctionalComponent<PlanCardProps> = (
       </div>
       <span class="ManifoldSubscriptionCreate__Cost">
         <span data-is-loading={isLoading}>
-          <CostDisplay baseCost={plan.cost} isConfigurable compact />
+          <CostDisplay
+            isCalculating={calculatedCost === undefined}
+            baseCost={calculatedCost || plan.cost || 0}
+            isConfigurable
+            compact
+          />
         </span>
       </span>
       {cta}

--- a/src/components/shared/PlanCard.tsx
+++ b/src/components/shared/PlanCard.tsx
@@ -7,7 +7,7 @@ import { UIError } from '../../utils/error';
 interface PlanCardProps {
   isLoading?: boolean;
   isChecked?: boolean;
-  calculatedCost?: number;
+  calculatedCost?: number | null;
   errors?: UIError[];
   plan?: {
     displayName: string;
@@ -47,7 +47,7 @@ const PlanCard: FunctionalComponent<PlanCardProps> = (props, cta) => {
       <span class="ManifoldSubscriptionCreate__Cost">
         <span data-is-loading={isLoading}>
           <CostDisplay
-            isCalculating={calculatedCost === undefined}
+            isCalculating={calculatedCost === null}
             baseCost={calculatedCost || plan.cost || 0}
             isConfigurable
             compact

--- a/src/components/shared/PlanSelector.tsx
+++ b/src/components/shared/PlanSelector.tsx
@@ -41,7 +41,7 @@ const PlanMenu: FunctionalComponent<PlanMenuProps> = ({
               setAllConfiguredFeatures(configurableFeatureDefaults(plans as PlanEdge[], plan.id));
             }}
           />
-          <PlanCard plan={plan} isChecked={plan.id === selectedPlanId} calculatedCost={0} />
+          <PlanCard plan={plan} isChecked={plan.id === selectedPlanId} />
         </label>
       </li>
     ))}
@@ -63,7 +63,7 @@ interface PlanSelectorProps {
   planId: PlanId;
   configuredFeatures: ConfiguredFeatures;
   errors: UIError[];
-  calculatedCost?: number;
+  calculatedCost?: number | null;
   data?: PlanListQuery;
   isLoading?: boolean;
 }
@@ -118,7 +118,7 @@ const PlanSelector: FunctionalComponent<PlanSelectorProps> = props => {
         <footer class="ManifoldSubscriptionCreate__PlanSelector__Footer">
           <div>
             <CostDisplay
-              isCalculating={props.calculatedCost === undefined}
+              isCalculating={props.calculatedCost === null}
               baseCost={props.calculatedCost || currentPlan?.cost || 0}
               meteredFeatures={currentPlan?.meteredFeatures.edges as PlanMeteredFeatureEdge[]}
               isConfigurable={

--- a/src/components/shared/PlanSelector.tsx
+++ b/src/components/shared/PlanSelector.tsx
@@ -41,7 +41,7 @@ const PlanMenu: FunctionalComponent<PlanMenuProps> = ({
               setAllConfiguredFeatures(configurableFeatureDefaults(plans as PlanEdge[], plan.id));
             }}
           />
-          <PlanCard plan={plan} isChecked={plan.id === selectedPlanId} />
+          <PlanCard plan={plan} isChecked={plan.id === selectedPlanId} calculatedCost={0} />
         </label>
       </li>
     ))}

--- a/src/styles/elements/_card.scss
+++ b/src/styles/elements/_card.scss
@@ -41,4 +41,10 @@ $name: '' !default;
     transform: scale(1);
     opacity: 1;
   }
+
+  &__ConfigurableIndicator {
+    margin-left: 0.5em;
+    font-size: 0.9em;
+    opacity: 0.5;
+  }
 }

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -603,6 +603,9 @@ export type Product = Node & {
   fixedFeatures: Maybe<ProductFixedFeatureConnection>;
   meteredFeatures: Maybe<ProductMeteredFeatureConnection>;
   configurableFeatures: Maybe<ProductConfigurableFeatureConnection>;
+  version: Maybe<Scalars['Int']>;
+  versionID: Maybe<Scalars['ID']>;
+  published: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -964,6 +967,7 @@ export type QueryPlanArgs = {
 export type QueryProductArgs = {
   id: Maybe<Scalars['ID']>;
   label: Maybe<Scalars['String']>;
+  latest: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -1219,6 +1223,7 @@ export type SubscriptionAgreement = Node & {
   id: Scalars['ID'];
   plan: Maybe<Plan>;
   status: SubscriptionAgreementStatus;
+  owner: Maybe<Profile>;
 };
 
 export type SubscriptionAgreementConnection = {
@@ -1432,6 +1437,15 @@ export type PlanQuery = (
     & { product: Maybe<(
       { __typename?: 'Product' }
       & Pick<Product, 'label'>
+    )>, configurableFeatures: Maybe<(
+      { __typename?: 'PlanConfigurableFeatureConnection' }
+      & { edges: Array<(
+        { __typename?: 'PlanConfigurableFeatureEdge' }
+        & { node: (
+          { __typename?: 'PlanConfigurableFeature' }
+          & Pick<PlanConfigurableFeature, 'id'>
+        ) }
+      )> }
     )> }
   )>, profile: (
     { __typename?: 'Profile' }


### PR DESCRIPTION
## Change

NOTE: Only look at the last commit. it's branched off my other brach to avoid conflicts

- Calculates cost on the plan card for configured features


## Testing

- the cost on the `!isEditing` view should match the plan selector cost in the `isEditing` view
