### PR TITLE
added plan selector store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1771,6 +1771,12 @@
       "integrity": "sha512-Nny3JiFkpQa0RdXWCa4pzhKQYnHuDNzC9c4w35FcaZHXBVuZ1UHSHc7wI7By9SS1auYcySqpPOBVzgoCqXcYVQ==",
       "dev": true
     },
+    "@stencil/store": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stencil/store/-/store-1.0.1.tgz",
+      "integrity": "sha512-O9DfH7gY4Qr6BJaiQStj38AMQzHPcGdQ8SofBzjb903ZSM7Mrs4QuKo5FvTWTgqMUzrVuKeaDVdlERmOvO9TvA==",
+      "dev": true
+    },
     "@stripe/stripe-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@stencil/core": "^1.10.1",
     "@stencil/postcss": "^1.0.1",
     "@stencil/sass": "^1.1.1",
+    "@stencil/store": "^1.0.1",
     "@types/jest": "24.0.20",
     "@types/puppeteer": "1.19.0",
     "@typescript-eslint/eslint-plugin": "^2.25.0",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -55,6 +55,7 @@ export namespace Components {
     }
     interface ManifoldSubscriptionDetails {
         "heading"?: string;
+        "isEditing"?: boolean;
         "subscriptionId": string;
     }
     interface ManifoldSubscriptionList {
@@ -152,6 +153,7 @@ declare namespace LocalJSX {
     }
     interface ManifoldSubscriptionDetails {
         "heading"?: string;
+        "isEditing"?: boolean;
         "subscriptionId"?: string;
     }
     interface ManifoldSubscriptionList {

--- a/src/components/manifold-subscription-details/components/PlanSelector.tsx
+++ b/src/components/manifold-subscription-details/components/PlanSelector.tsx
@@ -1,0 +1,22 @@
+import { h, FunctionalComponent } from '@stencil/core';
+import state from '../store';
+
+interface PlanSelectorProps {
+  productId: string;
+}
+
+const PlanSelector: FunctionalComponent<PlanSelectorProps> = ({ productId }) => {
+  state.productId = productId;
+
+  if (state.isLoading) {
+    return 'Loading...';
+  }
+
+  return (
+    <div class="ManifoldSubscriptionCreate__List__Card">
+      <pre>{JSON.stringify(state.plans, null, 2)}</pre>
+    </div>
+  );
+};
+
+export default PlanSelector;

--- a/src/components/manifold-subscription-details/manifold-subscription-details.tsx
+++ b/src/components/manifold-subscription-details/manifold-subscription-details.tsx
@@ -11,6 +11,8 @@ import {
   PlanMeteredFeatureEdge,
   PlanConfigurableFeatureEdge,
 } from '../../types/graphql';
+import state from './store';
+import PlanSelector from './components/PlanSelector';
 
 @Component({
   tag: 'manifold-subscription-details',
@@ -18,6 +20,7 @@ import {
 export class ManifoldSubscriptionCreate {
   @Prop() subscriptionId: string;
   @Prop() heading?: string;
+  @Prop() isEditing?: boolean = false;
   @State() data?: SubscriptionQuery;
   @Element() el: HTMLElement;
 
@@ -44,11 +47,15 @@ export class ManifoldSubscriptionCreate {
   async componentWillLoad() {
     await customElements.whenDefined('manifold-init');
     const core = document.querySelector('manifold-init') as HTMLManifoldInitElement;
-    this.connection = await core.initialize({
+
+    const connection = await core.initialize({
       element: this.el,
       componentVersion: '<@NPM_PACKAGE_VERSION@>',
       version: 0,
     });
+
+    state.connection = connection;
+    this.connection = connection;
 
     this.getSubscription(this.subscriptionId, '');
   }
@@ -56,6 +63,10 @@ export class ManifoldSubscriptionCreate {
   render() {
     if (!this.data || !this.data.subscription) {
       return null;
+    }
+
+    if (this.isEditing) {
+      return <PlanSelector productId={this.data.subscription.plan.product.id} />;
     }
 
     const { plan, status } = this.data.subscription;
@@ -92,7 +103,14 @@ export class ManifoldSubscriptionCreate {
               <CostDisplay baseCost={plan.cost} />
               <p class="ManifoldSubscriptionCreate__HelpText">Usage billed at the end of month</p>
             </div>
-            <button type="button" class="ManifoldSubscription__Button" data-kind="black">
+            <button
+              type="button"
+              class="ManifoldSubscription__Button"
+              data-kind="black"
+              onClick={() => {
+                this.isEditing = true;
+              }}
+            >
               Modify Subsciption
             </button>
           </footer>

--- a/src/components/manifold-subscription-details/product-plans.graphql
+++ b/src/components/manifold-subscription-details/product-plans.graphql
@@ -1,0 +1,69 @@
+fragment productPlan on Plan {
+  id
+  displayName
+  label
+  free
+  cost
+  fixedFeatures(first: 500) {
+    edges {
+      node {
+        displayName
+        displayValue
+        label
+      }
+    }
+  }
+  meteredFeatures(first: 500) {
+    edges {
+      node {
+        label
+        displayName
+        numericDetails {
+          unit
+          costTiers {
+            limit
+            cost
+          }
+        }
+      }
+    }
+  }
+  configurableFeatures(first: 500) {
+    edges {
+      node {
+        label
+        displayName
+        type
+        upgradable
+        downgradable
+        featureOptions {
+          displayName
+          value
+          cost
+        }
+        numericDetails {
+          increment
+          min
+          max
+          unit
+          costTiers {
+            limit
+            cost
+          }
+        }
+      }
+    }
+  }
+}
+
+query ProductPlans($productId: ID!) {
+  product(id: $productId) {
+    plans(first: 25, orderBy: { field: COST, direction: ASC }) {
+      edges {
+        node {
+          ...productPlan
+        }
+      }
+    }
+  }
+}

--- a/src/components/manifold-subscription-details/store.ts
+++ b/src/components/manifold-subscription-details/store.ts
@@ -1,0 +1,41 @@
+import { createStore } from '@stencil/store';
+import { Connection } from '@manifoldco/manifold-init-types/types/v0';
+import { GraphqlError } from '@manifoldco/manifold-init-types/types/v0/graphqlFetch';
+import { ProductPlansQuery, ProductPlansQueryVariables } from '../../types/graphql';
+import productPlansQuery from './product-plans.graphql';
+
+interface Store {
+  connection?: Connection;
+  productId?: string;
+  isLoading: boolean;
+  plans?: ProductPlansQuery['product']['plans']['edges'];
+  errors?: GraphqlError[];
+}
+
+const { state, onChange } = createStore<Store>({
+  isLoading: false,
+});
+
+onChange('productId', async (productId: string) => {
+  if (!state.connection?.graphqlFetch) {
+    return;
+  }
+
+  state.isLoading = true;
+
+  const variables: ProductPlansQueryVariables = { productId };
+  const { data, errors } = await state.connection.graphqlFetch<ProductPlansQuery>({
+    query: productPlansQuery,
+    variables,
+  });
+
+  state.errors = errors;
+
+  if (data) {
+    state.plans = data.product.plans.edges;
+  }
+
+  state.isLoading = false;
+});
+
+export default state;

--- a/src/components/manifold-subscription-details/subscription.graphql
+++ b/src/components/manifold-subscription-details/subscription.graphql
@@ -10,6 +10,9 @@ query Subscription($id: ID!) {
       label
       displayName
       cost
+      product {
+        id
+      }
       fixedFeatures(first: 500) {
         edges {
           node {

--- a/src/types/graphql.ts
+++ b/src/types/graphql.ts
@@ -1223,7 +1223,14 @@ export type SubscriptionAgreement = Node & {
   id: Scalars['ID'];
   plan: Maybe<Plan>;
   status: SubscriptionAgreementStatus;
+  configuredFeatures: Maybe<ConfiguredFeatureConnection>;
   owner: Maybe<Profile>;
+};
+
+
+export type SubscriptionAgreementConfiguredFeaturesArgs = {
+  first: Scalars['Int'];
+  after: Maybe<Scalars['String']>;
 };
 
 export type SubscriptionAgreementConnection = {
@@ -1448,6 +1455,80 @@ export type PlanQuery = (
   ) }
 );
 
+export type ProductPlanFragment = (
+  { __typename?: 'Plan' }
+  & Pick<Plan, 'id' | 'displayName' | 'label' | 'free' | 'cost'>
+  & { fixedFeatures: Maybe<(
+    { __typename?: 'PlanFixedFeatureConnection' }
+    & { edges: Array<(
+      { __typename?: 'PlanFixedFeatureEdge' }
+      & { node: (
+        { __typename?: 'PlanFixedFeature' }
+        & Pick<PlanFixedFeature, 'displayName' | 'displayValue' | 'label'>
+      ) }
+    )> }
+  )>, meteredFeatures: Maybe<(
+    { __typename?: 'PlanMeteredFeatureConnection' }
+    & { edges: Array<(
+      { __typename?: 'PlanMeteredFeatureEdge' }
+      & { node: (
+        { __typename?: 'PlanMeteredFeature' }
+        & Pick<PlanMeteredFeature, 'label' | 'displayName'>
+        & { numericDetails: (
+          { __typename?: 'PlanMeteredFeatureNumericDetails' }
+          & Pick<PlanMeteredFeatureNumericDetails, 'unit'>
+          & { costTiers: Maybe<Array<(
+            { __typename?: 'PlanFeatureCostTier' }
+            & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+          )>> }
+        ) }
+      ) }
+    )> }
+  )>, configurableFeatures: Maybe<(
+    { __typename?: 'PlanConfigurableFeatureConnection' }
+    & { edges: Array<(
+      { __typename?: 'PlanConfigurableFeatureEdge' }
+      & { node: (
+        { __typename?: 'PlanConfigurableFeature' }
+        & Pick<PlanConfigurableFeature, 'label' | 'displayName' | 'type' | 'upgradable' | 'downgradable'>
+        & { featureOptions: Maybe<Array<(
+          { __typename?: 'PlanConfigurableFeatureOption' }
+          & Pick<PlanConfigurableFeatureOption, 'displayName' | 'value' | 'cost'>
+        )>>, numericDetails: Maybe<(
+          { __typename?: 'PlanConfigurableFeatureNumericDetails' }
+          & Pick<PlanConfigurableFeatureNumericDetails, 'increment' | 'min' | 'max' | 'unit'>
+          & { costTiers: Maybe<Array<(
+            { __typename?: 'PlanFeatureCostTier' }
+            & Pick<PlanFeatureCostTier, 'limit' | 'cost'>
+          )>> }
+        )> }
+      ) }
+    )> }
+  )> }
+);
+
+export type ProductPlansQueryVariables = {
+  productId: Scalars['ID'];
+};
+
+
+export type ProductPlansQuery = (
+  { __typename?: 'Query' }
+  & { product: Maybe<(
+    { __typename?: 'Product' }
+    & { plans: Maybe<(
+      { __typename?: 'PlanConnection' }
+      & { edges: Array<(
+        { __typename?: 'PlanEdge' }
+        & { node: (
+          { __typename?: 'Plan' }
+          & ProductPlanFragment
+        ) }
+      )> }
+    )> }
+  )> }
+);
+
 export type SubscriptionQueryVariables = {
   id: Scalars['ID'];
 };
@@ -1463,7 +1544,10 @@ export type SubscriptionQuery = (
     ), plan: Maybe<(
       { __typename?: 'Plan' }
       & Pick<Plan, 'id' | 'label' | 'displayName' | 'cost'>
-      & { fixedFeatures: Maybe<(
+      & { product: Maybe<(
+        { __typename?: 'Product' }
+        & Pick<Product, 'id'>
+      )>, fixedFeatures: Maybe<(
         { __typename?: 'PlanFixedFeatureConnection' }
         & { edges: Array<(
           { __typename?: 'PlanFixedFeatureEdge' }


### PR DESCRIPTION
## Change

- Open editing state when the "Modify Plan" button is clicked
- Added a plan selector with a shiny new Stencil Store


## Testing

- get a subscription id and manifold token from taco cloud and add it the the details component in index.html
- when the details component loads, click on the "Modify Plan" button
- a new view should load showing the fetched plans data